### PR TITLE
Removes newline in error message

### DIFF
--- a/packages/metal-state/src/State.js
+++ b/packages/metal-state/src/State.js
@@ -193,7 +193,7 @@ class State extends EventEmitter {
 				info.initialValue;
 			if (!core.isDefAndNotNull(value)) {
 				console.error(
-					'The property called "' + name + '" is required but didn\n\'t ' +
+					'The property called "' + name + '" is required but didn\'t ' +
 					'receive a value.'
 				);
 			}


### PR DESCRIPTION
I'm assuming it was just a typo, noticed it in the developer console.
