### PR TITLE
Updates LISTENER_REGEX value to accept anything after `on` or `data-on`

### DIFF
--- a/packages/metal-incremental-dom/src/IncrementalDomRenderer.js
+++ b/packages/metal-incremental-dom/src/IncrementalDomRenderer.js
@@ -912,7 +912,7 @@ var emptyChildren_ = [];
 
 
 // Regex pattern used to find inline listeners.
-IncrementalDomRenderer.LISTENER_REGEX = /^(?:on([A-Z]\w+))|(?:data-on(\w+))$/;
+IncrementalDomRenderer.LISTENER_REGEX = /^(?:on([A-Z].+))|(?:data-on(.+))$/;
 
 // Name of this renderer. Renderers should provide this as a way to identify
 // them via a simple string (when calling enableCompatibilityMode to add

--- a/packages/metal-incremental-dom/test/IncrementalDomRenderer.js
+++ b/packages/metal-incremental-dom/test/IncrementalDomRenderer.js
@@ -603,6 +603,27 @@ describe('IncrementalDomRenderer', function() {
 			assert.strictEqual('handleClick', component.element.getAttribute('data-onclick'));
 		});
 
+		it('should attach listeners from "data-on<event-name>" attributes', function() {
+			dom.registerCustomEvent('test-event', {
+  			delegate: true,
+  			handler: (callback, event) => callback(event),
+  			originalEvent: 'click'
+			});
+
+			class TestComponent extends Component {
+				render() {
+					IncDom.elementVoid('div', null, null, 'data-ontest-event', 'handleClick');
+				}
+			}
+			TestComponent.RENDERER = IncrementalDomRenderer;
+			TestComponent.prototype.handleClick = sinon.stub();
+
+			component = new TestComponent();
+
+			dom.triggerEvent(component.element, 'click');
+			assert.strictEqual(1, component.handleClick.callCount);
+		});
+
 		it('should attach listeners from attributes in existing elements', function() {
 			class TestComponent extends Component {
 				render() {
@@ -775,6 +796,27 @@ describe('IncrementalDomRenderer', function() {
 			assert.strictEqual(0, component.handleClick.callCount);
 
 			dom.triggerEvent(component.element.childNodes[0], 'click');
+			assert.strictEqual(1, component.handleClick.callCount);
+		});
+
+		it('should attach listeners from "on<Event-name>" attributes', function() {
+			dom.registerCustomEvent('test-event', {
+  			delegate: true,
+  			handler: (callback, event) => callback(event),
+  			originalEvent: 'click'
+			});
+
+			class TestComponent extends Component {
+				render() {
+					IncDom.elementVoid('div', null, null, 'onTest-event', 'handleClick');
+				}
+			}
+			TestComponent.RENDERER = IncrementalDomRenderer;
+			TestComponent.prototype.handleClick = sinon.stub();
+
+			component = new TestComponent();
+
+			dom.triggerEvent(component.element, 'click');
 			assert.strictEqual(1, component.handleClick.callCount);
 		});
 


### PR DESCRIPTION
This is a requirement for this issue https://github.com/metal/metal.js/issues/168.

The intention is reducing the specificity of the regex to accept a `-` character after the event name like `data-onkeydown-enter`. 

This will be used for the new Metal-Key module https://github.com/metal/metal-key.