### PR TITLE
Implement "prepareStateForRender" — Fixes #178

### DIFF
--- a/packages/metal-soy/src/Soy.js
+++ b/packages/metal-soy/src/Soy.js
@@ -54,6 +54,7 @@ class Soy extends IncrementalDomRenderer.constructor {
 			}
 			data[key] = value;
 		});
+
 		for (let i = 0; i < params.length; i++) {
 			if (!data[params[i]] && isFunction(component[params[i]])) {
 				data[params[i]] = component[params[i]].bind(component);

--- a/packages/metal-soy/src/Soy.js
+++ b/packages/metal-soy/src/Soy.js
@@ -40,6 +40,8 @@ class Soy extends IncrementalDomRenderer.constructor {
 	 * template call's data. The copying needs to be done because, if the component
 	 * itself is passed directly, some problems occur when soy tries to merge it
 	 * with other data, due to property getters and setters. This is safer.
+	 * Also calls the component's "prepareStateForRender" to let it change the
+	 * data passed to the template.
 	 * @param {!Component} component
 	 * @param {!Array<string>} params The params used by this template.
 	 * @return {!Object}
@@ -60,7 +62,12 @@ class Soy extends IncrementalDomRenderer.constructor {
 				data[params[i]] = component[params[i]].bind(component);
 			}
 		}
-		return data;
+
+		if (isFunction(component.prepareStateForRender)) {
+			return component.prepareStateForRender(data) || data;
+		} else {
+			return data;
+		}
 	}
 
 	/**

--- a/packages/metal-soy/test/Soy.js
+++ b/packages/metal-soy/test/Soy.js
@@ -11,6 +11,7 @@ import { Events as EventsComponent } from './assets/Events.soy.js';
 // on it.
 // TODO: We should have a better dependency management for soy files so that
 // the order in which they're required doesn't matter.
+import { ComputedData as ComputedDataComponent } from './assets/ComputedData.soy.js';
 import { ExternalTemplate as ExternalTemplateComponent } from './assets/ExternalTemplate.soy.js';
 import { Functions as FunctionsComponent } from './assets/Functions.soy.js';
 import { HtmlContent as HtmlContentComponent } from './assets/HtmlContent.soy.js';
@@ -108,6 +109,27 @@ describe('Soy', function() {
 				comp.foo = 'Bar';
 				comp.once('stateSynced', function() {
 					assert.strictEqual(1, IncrementalDOM.patchOuter.callCount);
+					done();
+				});
+			});
+
+			it('should pass state values to "prepareStateForRender" and use them in the template', function(done) {
+				ComputedDataComponent.prototype.shouldUpdate = function() {
+					return true;
+				};
+
+				ComputedDataComponent.prototype.prepareStateForRender = function(data) {
+					data.name = data.name.split('').reverse().join('');
+				};
+
+				comp = new ComputedDataComponent({ name: 'Foo' });
+
+				assert.strictEqual('ooF', comp.element.textContent);
+
+				comp.name = 'Bar';
+
+				comp.once('stateSynced', function() {
+					assert.strictEqual('raB', comp.element.textContent);
 					done();
 				});
 			});

--- a/packages/metal-soy/test/assets/ComputedData.soy
+++ b/packages/metal-soy/test/assets/ComputedData.soy
@@ -1,0 +1,10 @@
+{namespace ComputedData}
+
+/**
+ * @param name
+ */
+{template .render}
+	<div>
+		{$name}
+	</div>
+{/template}


### PR DESCRIPTION
Let Soy components define "prepareStateForRender" to manipulate data:

While in JSXComponents there’s a place to compute derived values from the state just before rendering (that’s the "render" method), on Soy components there’s no way to do the same.

This change makes the Soy renderer to call a "prepareStateForRender" method on the component, passing the data that would be used for the template and trusting the implementation to do one of the following:
- mutate the original template data and return it;
- mutate the original template data and return undefined;
- create a new object and return it (eventually mixing in the original data).

Fixes #178