### PR TITLE
Updates for latest metal-devtools changes

### DIFF
--- a/packages/metal-component/src/Component.js
+++ b/packages/metal-component/src/Component.js
@@ -439,8 +439,8 @@ class Component extends EventEmitter {
 		}
 		const instance = new Ctor(config, false);
 
-		if (window.__METAL_DEV_TOOLS_HOOK__) {
-			window.__METAL_DEV_TOOLS_HOOK__(instance);
+		if (window.__METAL_DEV_TOOLS_HOOK__ && window.__METAL_DEV_TOOLS_HOOK__.addRoot) {
+			window.__METAL_DEV_TOOLS_HOOK__.addRoot(instance);
 		}
 
 		instance.renderComponent(element);

--- a/packages/metal-component/test/Component.js
+++ b/packages/metal-component/test/Component.js
@@ -940,9 +940,12 @@ describe('Component', function() {
 		assert.ok(!Component.isComponentCtor(fn.bind(this)));
 	});
 
-	it('should pass instance of component to __METAL_DEV_TOOLS_HOOK__  in Component.render', function() {
-		var hookStub = sinon.stub();
-		window.__METAL_DEV_TOOLS_HOOK__ = hookStub;
+	it('should pass instance of component to __METAL_DEV_TOOLS_HOOK__.addRoot  in Component.render', function() {
+		var addStub = sinon.stub();
+		var oldValue = window.__METAL_DEV_TOOLS_HOOK__;
+		window.__METAL_DEV_TOOLS_HOOK__ = {
+			addRoot: addStub
+		};
 		class CustomComponent extends Component {
 			constructor(...args) {
 				super(...args);
@@ -955,8 +958,10 @@ describe('Component', function() {
 		assert.ok(comp instanceof CustomComponent);
 		assert.ok(comp.wasRendered);
 		assert.ok(comp.element);
-		sinon.assert.callCount(hookStub, 1);
-		sinon.assert.calledWith(hookStub, comp);
+		sinon.assert.callCount(addStub, 1);
+		sinon.assert.calledWith(addStub, comp);
+
+		window.__METAL_DEV_TOOLS_HOOK__ = oldValue;
 	});
 
 	function createCustomComponentClass(opt_rendererContentOrFn) {


### PR DESCRIPTION
See https://github.com/metal/metal.js/pull/196

Using method on `window.__METAL_DEV_TOOLS_HOOK__` object instead so that we can keep track of all root components.

@jbalsas , I decided to not add the backwards compatibility to the original release of metal-devtools because. That release had some major bugs and it isn't expected that anyone would use that.