### PR TITLE
Move hook to 'renderComponent'

### DIFF
--- a/packages/metal-component/src/Component.js
+++ b/packages/metal-component/src/Component.js
@@ -438,11 +438,6 @@ class Component extends EventEmitter {
 			element = opt_configOrElement;
 		}
 		const instance = new Ctor(config, false);
-
-		if (window.__METAL_DEV_TOOLS_HOOK__) {
-			window.__METAL_DEV_TOOLS_HOOK__(instance);
-		}
-
 		instance.renderComponent(element);
 		return instance;
 	}
@@ -457,6 +452,9 @@ class Component extends EventEmitter {
 	 */
 	renderComponent(opt_parentElement) {
 		if (!this.hasRendererRendered_) {
+			if (window.__METAL_DEV_TOOLS_HOOK__) {
+				window.__METAL_DEV_TOOLS_HOOK__(this);
+			}
 			this.getRenderer().render(this);
 		}
 		this.emit('render');

--- a/packages/metal-component/test/Component.js
+++ b/packages/metal-component/test/Component.js
@@ -940,7 +940,7 @@ describe('Component', function() {
 		assert.ok(!Component.isComponentCtor(fn.bind(this)));
 	});
 
-	it('should pass instance of component to __METAL_DEV_TOOLS_HOOK__  in Component.render', function() {
+	it('should pass instance of component to __METAL_DEV_TOOLS_HOOK__ on first render', function() {
 		var hookStub = sinon.stub();
 		window.__METAL_DEV_TOOLS_HOOK__ = hookStub;
 		class CustomComponent extends Component {
@@ -955,6 +955,11 @@ describe('Component', function() {
 		assert.ok(comp instanceof CustomComponent);
 		assert.ok(comp.wasRendered);
 		assert.ok(comp.element);
+		sinon.assert.callCount(hookStub, 1);
+		sinon.assert.calledWith(hookStub, comp);
+
+		comp.visible = false;
+
 		sinon.assert.callCount(hookStub, 1);
 		sinon.assert.calledWith(hookStub, comp);
 	});


### PR DESCRIPTION
This allows us to use the hook on components that are not instantiated by the static render method.