### PR TITLE
Remove useless line in the tests:

### DIFF
--- a/packages/metal-soy/test/Soy.js
+++ b/packages/metal-soy/test/Soy.js
@@ -148,7 +148,6 @@ describe('Soy', function() {
 			}
 			NoTemplateComponent.RENDERER = Soy;
 
-			comp = new NoTemplateComponent();
 			assert.doesNotThrow(function() {
 				comp = new NoTemplateComponent();
 			});


### PR DESCRIPTION
The execution of the component’s constructor would have happened anyway in the `assert.doesNotThrow` block.