### PR TITLE
Evaluate links with rel canonical and alternate

### DIFF
--- a/packages/metal-dom/src/globalEvalStyles.js
+++ b/packages/metal-dom/src/globalEvalStyles.js
@@ -55,12 +55,21 @@ class globalEvalStyles {
 		const callback = function() {
 			defaultFn && defaultFn();
 		};
-		if (style.rel && style.rel !== 'stylesheet') {
+		if (
+			style.rel &&
+			style.rel !== 'stylesheet' &&
+			style.rel !== 'canonical' &&
+			style.rel !== 'alternate'
+		) {
 			async.nextTick(callback);
 			return;
 		}
 
-		if (style.tagName === 'STYLE') {
+		if (
+			style.tagName === 'STYLE' ||
+			style.rel === 'canonical' ||
+			style.rel === 'alternate'
+		) {
 			async.nextTick(callback);
 		} else {
 			once(style, 'load', callback);


### PR DESCRIPTION
Hey @jbalsas, this fixes the senna problem not crawling `canonical` or `alternate` links.