### PR TITLE
Update Travis CI to use Ubuntu Bionic (18.04)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+os: linux
+dist: bionic
+
 addons:
   sauce_connect:
     username: metal-js
@@ -17,7 +20,7 @@ install:
   - npm run lerna
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 language: java
 


### PR DESCRIPTION
The default is Ubuntu Xenial (16.04) as per:
https://docs.travis-ci.com/user/reference/overview/#linux

Also switch from Oracle JDK 8 to OpenJDK 8, since Oracle JDK 8 is no longer
available, as per https://travis-ci.org/github/metal/metal.js/builds/708924115

> ```
> $ ~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"
> Ignoring license option: BCL -- using GPLv2+CE by default
> install-jdk.sh 2020-06-02
> Expected feature release number in range of 9 to 16, but got: 8
> The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .
> ```