### PR TITLE
Update Sauce Labs badge style & link [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # Metal.js
 
-[![Build Status](https://img.shields.io/travis/metal/metal.js/master.svg?style=flat)](https://travis-ci.org/metal/metal.js)
-Join #metal on our [Slack Channel](https://community.liferay.com/chat)
-
-[![Build Status](https://saucelabs.com/browser-matrix/metal-js.svg)](https://saucelabs.com/beta/builds/a0b06f2845e541c78db25576f2ddc501)
+[![Travis CI build status](https://img.shields.io/travis/metal/metal.js/develop.svg?style=flat)](https://travis-ci.org/metal/metal.js)
+[![Sauce Labs build status](https://app.saucelabs.com/buildstatus/metal-js)](https://app.saucelabs.com/open_sauce/user/metal-js/builds)
 
 Metal.js is a JavaScript library for building UI components in a solid, flexible way.
 
 * [Official website](http://metaljs.com)
+* Join the `#p-metal` channel on our [Slack community](https://community.liferay.com/chat)
 
 ## Setup
 


### PR DESCRIPTION
* update Sauce Labs badge visual style to match Travis CI style, which also
  matches the thickness for them to fit on a single line together
* point Sauce Labs badge URL to the live status page for all Metal.js builds,
  instead of a specific build, as that's not really useful as it becomes
  out-of-date immediately
* update Travis CI badge to use the `develop` branch instead of `master`, since
  ongoing development happens on `develop` and `master` is only updated for each
  release, so it doesn't change very often
* move invitation to join the Slack community from between the two build status
  badges to below the official website as they are both communication channels,
  which allows us to put the two build status badges close together at the top
  of the page